### PR TITLE
feat: add import resolution tracer (pywho trace)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.2.0] - 2026-03-15
+
+### Added
+
+- `pywho trace <module>` subcommand for import resolution tracing
+- Shows where an import resolves and the full sys.path search order
+- Shadow detection: warns when local files shadow stdlib or installed packages
+- `--verbose` flag for full sys.path search log
+- `--json` flag for trace output
+- `trace_import()` Python API with `TraceReport` dataclass
+- New docs pages for the trace feature
+
 ## [0.1.0] - 2026-03-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # pywho
 
-**One command to explain your Python environment.**
+**One command to explain your Python environment and trace import resolution.**
 
-Ever asked *"Which Python am I running? Why is it using that venv? Where are my packages?"* — pywho answers all of it instantly.
+Ever asked *"Which Python am I running? Why is it using that venv? Why did `import X` load that file?"* — pywho answers all of it instantly.
 
 ```
 $ pywho
@@ -116,6 +116,46 @@ pywho --no-pip
 python -m pywho
 ```
 
+### Trace an import
+
+```bash
+pywho trace requests
+```
+
+```
+  Import Resolution: requests
+  ========================================
+
+  Resolved to: /Users/dev/.venv/lib/python3.12/site-packages/requests/__init__.py
+  Module type: third-party (package)
+  Cached:      No
+
+  Search order:
+    [0] /Users/dev/myproject        -> not found
+    [1] /usr/lib/python3.12         -> not found
+    [2] ~/.venv/lib/.../site-packages -> FOUND
+```
+
+### Trace with full search log
+
+```bash
+pywho trace json --verbose
+```
+
+### Trace with JSON output
+
+```bash
+pywho trace requests --json
+```
+
+### Detect import shadows
+
+```bash
+$ pywho trace requests
+
+  WARNING: './requests.py' shadows installed package 'requests'
+```
+
 ## As a Python library
 
 ```python
@@ -130,6 +170,23 @@ print(report.package_manager)   # "uv"
 
 # Get JSON-serializable dict
 data = report.to_dict()
+```
+
+### Trace imports programmatically
+
+```python
+from pywho import trace_import
+
+trace = trace_import("requests")
+print(trace.resolved_path)    # /path/to/requests/__init__.py
+print(trace.module_type)      # ModuleType.THIRD_PARTY
+print(trace.is_cached)        # True
+print(trace.shadows)          # [] (empty = no shadows)
+
+# Check for shadows
+if trace.shadows:
+    for s in trace.shadows:
+        print(f"WARNING: {s.description}")
 ```
 
 ## What it detects

--- a/docs/api.md
+++ b/docs/api.md
@@ -96,3 +96,69 @@ Frozen dataclass for an installed package.
 | `name` | `str` | Package name |
 | `version` | `str` | Installed version |
 | `location` | `str` | Installation path |
+
+---
+
+## `trace_import`
+
+```python
+from pywho import trace_import
+
+report = trace_import("requests", verbose=False)
+```
+
+**Parameters:**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `module_name` | `str` | *(required)* | Module to trace (e.g., `"requests"`, `"os.path"`) |
+| `verbose` | `bool` | `False` | Include all sys.path entries in search log |
+
+**Returns:** `TraceReport`
+
+---
+
+## `TraceReport`
+
+Frozen dataclass containing the full import resolution trace.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `module_name` | `str` | The module that was traced |
+| `resolved_path` | `str \| None` | File path the import resolves to (`None` if not found) |
+| `module_type` | `ModuleType` | Classification: `STDLIB`, `THIRD_PARTY`, `LOCAL`, `BUILTIN`, `FROZEN`, `NOT_FOUND` |
+| `is_package` | `bool` | Whether the module is a package (has `__init__.py`) |
+| `is_cached` | `bool` | Whether the module was already in `sys.modules` |
+| `submodule_of` | `str \| None` | Parent module name for dotted imports (e.g., `"os"` for `"os.path"`) |
+| `search_log` | `list[PathSearchEntry]` | sys.path entries that were checked |
+| `shadows` | `list[ShadowWarning]` | Detected import shadows |
+
+### Methods
+
+#### `to_dict() -> dict`
+
+Returns a JSON-serializable dictionary of the full trace.
+
+---
+
+## `PathSearchEntry`
+
+Frozen dataclass for one entry in the sys.path search log.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `path` | `str` | The sys.path entry that was checked |
+| `result` | `SearchResult` | `FOUND`, `NOT_FOUND`, or `SKIPPED` |
+| `candidate` | `str \| None` | File path found (if result is `FOUND`) |
+
+---
+
+## `ShadowWarning`
+
+Frozen dataclass for a detected import shadow.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `shadow_path` | `str` | Path of the file causing the shadow |
+| `shadowed_module` | `str` | Name of the module being shadowed |
+| `description` | `str` | Human-readable description of the shadow |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -46,11 +46,50 @@ python -m pywho
 pywho --json --packages
 ```
 
+## Import tracing
+
+### Trace where an import resolves
+
+```bash
+pywho trace requests
+```
+
+Shows:
+
+- The resolved file path
+- Module type (stdlib, third-party, local, builtin)
+- Whether it's cached in `sys.modules`
+- The sys.path search order
+- Shadow warnings (if a local file shadows a real module)
+
+### Full search log
+
+```bash
+pywho trace json --verbose
+```
+
+Shows every sys.path entry that was checked, not just the abbreviated version.
+
+### JSON trace output
+
+```bash
+pywho trace requests --json
+```
+
+### Shadow detection
+
+If a local file shadows a stdlib or installed package, you'll see:
+
+```
+WARNING: './requests.py' shadows installed package 'requests'
+```
+
 ## Exit codes
 
 | Code | Meaning |
 |------|---------|
-| `0`  | Success |
+| `0`  | Success (no shadows for `trace`) |
+| `1`  | Shadows detected (for `trace`) |
 
 ## Python library
 
@@ -99,4 +138,25 @@ pywho --json > env-b.json
 
 # Diff
 diff env-a.json env-b.json
+```
+
+### Debug a mysterious ImportError
+
+```bash
+pywho trace requests
+# Shows exactly which file Python is loading and if it's shadowed
+```
+
+### Trace imports in Python code
+
+```python
+from pywho import trace_import
+
+trace = trace_import("requests")
+print(trace.resolved_path)
+print(trace.module_type)
+
+if trace.shadows:
+    for s in trace.shadows:
+        print(f"WARNING: {s.description}")
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pywho"
-version = "0.1.0"
-description = "One command to explain your Python environment: interpreter, venv, packages, sys.path, and more."
+version = "0.2.0"
+description = "One command to explain your Python environment and trace import resolution."
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.9"
@@ -14,7 +14,7 @@ authors = [
 ]
 keywords = [
     "python", "environment", "debug", "venv", "virtualenv",
-    "interpreter", "diagnostic", "cli", "devtools",
+    "interpreter", "diagnostic", "cli", "devtools", "import", "trace",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/src/pywho/__init__.py
+++ b/src/pywho/__init__.py
@@ -1,6 +1,13 @@
 """pywho - One command to explain your Python environment."""
 
 from pywho.inspector import inspect_environment, EnvironmentReport
+from pywho.tracer import trace_import, TraceReport
 
-__version__ = "0.1.0"
-__all__ = ["inspect_environment", "EnvironmentReport", "__version__"]
+__version__ = "0.2.0"
+__all__ = [
+    "inspect_environment",
+    "EnvironmentReport",
+    "trace_import",
+    "TraceReport",
+    "__version__",
+]

--- a/src/pywho/cli.py
+++ b/src/pywho/cli.py
@@ -10,6 +10,8 @@ from typing import Optional, Sequence
 from pywho import __version__
 from pywho.formatter import format_report
 from pywho.inspector import inspect_environment
+from pywho.trace_formatter import format_trace
+from pywho.tracer import trace_import
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -17,6 +19,30 @@ def _build_parser() -> argparse.ArgumentParser:
         prog="pywho",
         description="Explain your Python environment in one command.",
     )
+    subparsers = parser.add_subparsers(dest="command")
+
+    # --- trace subcommand ---
+    trace_parser = subparsers.add_parser(
+        "trace",
+        help="Trace where an import resolves and why.",
+    )
+    trace_parser.add_argument(
+        "module",
+        help="Module name to trace (e.g., requests, json, os.path).",
+    )
+    trace_parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Show all sys.path entries, including skipped ones.",
+    )
+    trace_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Output as JSON.",
+    )
+
+    # --- top-level flags (for default env report) ---
     parser.add_argument(
         "--json",
         action="store_true",
@@ -41,11 +67,21 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(argv: Optional[Sequence[str]] = None) -> int:
-    """Entry point for the CLI."""
-    parser = _build_parser()
-    args = parser.parse_args(argv)
+def _run_trace(args: argparse.Namespace) -> int:
+    """Handle the 'trace' subcommand."""
+    report = trace_import(args.module, verbose=args.verbose)
 
+    if args.json_output:
+        print(json.dumps(report.to_dict(), indent=2))
+    else:
+        print(format_trace(report))
+
+    # Exit 1 if shadows detected, 0 otherwise
+    return 1 if report.shadows else 0
+
+
+def _run_inspect(args: argparse.Namespace) -> int:
+    """Handle the default environment inspection."""
     report = inspect_environment(include_packages=args.packages)
 
     if args.json_output:
@@ -54,6 +90,17 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         print(format_report(report, show_packages=args.packages))
 
     return 0
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """Entry point for the CLI."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "trace":
+        return _run_trace(args)
+
+    return _run_inspect(args)
 
 
 if __name__ == "__main__":

--- a/src/pywho/trace_formatter.py
+++ b/src/pywho/trace_formatter.py
@@ -1,0 +1,105 @@
+"""Terminal formatting for import trace reports."""
+
+from __future__ import annotations
+
+import sys
+from typing import List
+
+from pywho.tracer import ModuleType, SearchResult, TraceReport
+
+
+# ANSI escape codes
+_BOLD = "\033[1m"
+_DIM = "\033[2m"
+_RESET = "\033[0m"
+_CYAN = "\033[36m"
+_GREEN = "\033[32m"
+_YELLOW = "\033[33m"
+_RED = "\033[91m"
+_MAGENTA = "\033[35m"
+_WHITE = "\033[37m"
+
+
+def _supports_color() -> bool:
+    """Check if stdout supports ANSI colors."""
+    if hasattr(sys.stdout, "isatty") and sys.stdout.isatty():
+        return True
+    if "ANSICON" in __import__("os").environ:
+        return True
+    if "WT_SESSION" in __import__("os").environ:
+        return True
+    return False
+
+
+def _c(text: str, code: str) -> str:
+    if _supports_color():
+        return f"{code}{text}{_RESET}"
+    return text
+
+
+def format_trace(report: TraceReport) -> str:
+    """Format a TraceReport for terminal display."""
+    lines: List[str] = []
+
+    lines.append("")
+    header = f"  Import Resolution: {report.module_name}"
+    lines.append(_c(header, _BOLD + _CYAN))
+    lines.append(_c("  " + "=" * (len(header) - 2), _DIM))
+
+    # Shadows — show warnings first if any
+    if report.shadows:
+        lines.append("")
+        for shadow in report.shadows:
+            lines.append(_c(f"  WARNING: {shadow.description}", _BOLD + _RED))
+        lines.append("")
+
+    # Resolution
+    lines.append("")
+    if report.resolved_path:
+        lines.append(f"    {_c('Resolved to:', _WHITE)} {_c(report.resolved_path, _GREEN)}")
+    else:
+        lines.append(f"    {_c('Resolved to:', _WHITE)} {_c('NOT FOUND', _RED)}")
+
+    # Module type
+    type_color = {
+        ModuleType.STDLIB: _CYAN,
+        ModuleType.THIRD_PARTY: _GREEN,
+        ModuleType.LOCAL: _YELLOW,
+        ModuleType.BUILTIN: _MAGENTA,
+        ModuleType.FROZEN: _MAGENTA,
+        ModuleType.NOT_FOUND: _RED,
+    }
+    mtype = report.module_type.value
+    if report.is_package:
+        mtype += " (package)"
+    lines.append(f"    {_c('Module type:', _WHITE)} {_c(mtype, type_color.get(report.module_type, _WHITE))}")
+
+    # Cached
+    cached_str = "Yes (in sys.modules)" if report.is_cached else "No"
+    lines.append(f"    {_c('Cached:', _WHITE)}      {_c(cached_str, _GREEN if report.is_cached else _DIM)}")
+
+    # Submodule
+    if report.submodule_of:
+        lines.append(f"    {_c('Submodule of:', _WHITE)} {_c(report.submodule_of, _CYAN)}")
+
+    # Search order
+    if report.search_log:
+        lines.append("")
+        lines.append(f"    {_c('Search order:', _BOLD + _WHITE)}")
+        for i, entry in enumerate(report.search_log):
+            idx = _c(f"[{i}]", _DIM)
+            path = entry.path
+
+            if entry.result == SearchResult.FOUND:
+                status = _c("FOUND", _BOLD + _GREEN)
+                lines.append(f"      {idx} {path}")
+                lines.append(f"           -> {status} {_c(entry.candidate or '', _GREEN)}")
+            elif entry.result == SearchResult.NOT_FOUND:
+                status = _c("not found", _DIM)
+                lines.append(f"      {idx} {path} -> {status}")
+            else:
+                status = _c("skipped", _DIM)
+                lines.append(f"      {idx} {path} -> {status}")
+
+    lines.append("")
+    return "\n".join(lines)

--- a/src/pywho/tracer.py
+++ b/src/pywho/tracer.py
@@ -131,18 +131,19 @@ def _classify_module(
     if spec.origin == "frozen":
         return ModuleType.FROZEN
 
+    origin = spec.origin or ""
+
+    # Check site-packages FIRST — on some platforms (macOS system Python),
+    # site-packages lives under the same prefix as stdlib
+    if "site-packages" in origin or "dist-packages" in origin:
+        return ModuleType.THIRD_PARTY
+
     if name in _get_stdlib_names() or name in sys.builtin_module_names:
         return ModuleType.STDLIB
 
-    origin = spec.origin or ""
     stdlib_path = os.path.dirname(os.__file__)
     if origin.startswith(stdlib_path):
         return ModuleType.STDLIB
-
-    # Check if it's in a site-packages directory
-    for path_entry in sys.path:
-        if "site-packages" in path_entry and origin.startswith(path_entry):
-            return ModuleType.THIRD_PARTY
 
     return ModuleType.LOCAL
 

--- a/src/pywho/tracer.py
+++ b/src/pywho/tracer.py
@@ -1,0 +1,323 @@
+"""Import resolution tracer — explains where an import resolves and why."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Dict, List, Optional, Set
+
+
+class ModuleType(Enum):
+    """Classification of a resolved module."""
+
+    STDLIB = "stdlib"
+    THIRD_PARTY = "third-party"
+    LOCAL = "local"
+    BUILTIN = "builtin"
+    FROZEN = "frozen"
+    NOT_FOUND = "not-found"
+
+
+class SearchResult(Enum):
+    """Result of checking a single sys.path entry."""
+
+    FOUND = "found"
+    NOT_FOUND = "not-found"
+    SKIPPED = "skipped"
+
+
+@dataclass(frozen=True)
+class PathSearchEntry:
+    """One entry in the sys.path search log."""
+
+    path: str
+    result: SearchResult
+    candidate: Optional[str] = None  # file that was found (if any)
+
+
+@dataclass(frozen=True)
+class ShadowWarning:
+    """A detected import shadow."""
+
+    shadow_path: str
+    shadowed_module: str
+    description: str
+
+
+@dataclass(frozen=True)
+class TraceReport:
+    """Complete import resolution trace for a single module."""
+
+    module_name: str
+    resolved_path: Optional[str]
+    module_type: ModuleType
+    is_package: bool
+    is_cached: bool
+    submodule_of: Optional[str]
+    search_log: List[PathSearchEntry] = field(default_factory=list)
+    shadows: List[ShadowWarning] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, object]:
+        """Serialize to a JSON-compatible dictionary."""
+        return {
+            "module_name": self.module_name,
+            "resolved_path": self.resolved_path,
+            "module_type": self.module_type.value,
+            "is_package": self.is_package,
+            "is_cached": self.is_cached,
+            "submodule_of": self.submodule_of,
+            "search_log": [
+                {
+                    "path": e.path,
+                    "result": e.result.value,
+                    "candidate": e.candidate,
+                }
+                for e in self.search_log
+            ],
+            "shadows": [
+                {
+                    "shadow_path": s.shadow_path,
+                    "shadowed_module": s.shadowed_module,
+                    "description": s.description,
+                }
+                for s in self.shadows
+            ],
+        }
+
+
+def _get_stdlib_names() -> Set[str]:
+    """Return stdlib module names."""
+    if hasattr(sys, "stdlib_module_names"):
+        return set(sys.stdlib_module_names)
+    # Fallback for 3.9
+    return {
+        "abc", "argparse", "ast", "asyncio", "base64", "bisect", "builtins",
+        "calendar", "cmath", "cmd", "code", "codecs", "collections",
+        "configparser", "contextlib", "copy", "csv", "ctypes", "dataclasses",
+        "datetime", "decimal", "difflib", "dis", "email", "enum", "errno",
+        "fnmatch", "fractions", "ftplib", "functools", "gc", "getpass",
+        "glob", "gzip", "hashlib", "heapq", "hmac", "html", "http",
+        "importlib", "inspect", "io", "itertools", "json", "keyword",
+        "linecache", "locale", "logging", "lzma", "math", "mimetypes",
+        "multiprocessing", "numbers", "operator", "os", "pathlib", "pdb",
+        "pickle", "platform", "pprint", "profile", "pstats", "queue",
+        "random", "re", "readline", "reprlib", "resource", "sched",
+        "secrets", "select", "shelve", "shlex", "shutil", "signal",
+        "site", "smtplib", "socket", "socketserver", "sqlite3", "ssl",
+        "stat", "statistics", "string", "struct", "subprocess", "sys",
+        "sysconfig", "tarfile", "tempfile", "textwrap", "threading",
+        "time", "timeit", "token", "tokenize", "traceback", "types",
+        "typing", "unicodedata", "unittest", "urllib", "uuid", "venv",
+        "warnings", "weakref", "webbrowser", "xml", "xmlrpc", "zipfile",
+        "zipimport", "zlib",
+    }
+
+
+def _classify_module(
+    name: str,
+    spec: Optional[importlib.machinery.ModuleSpec],
+) -> ModuleType:
+    """Classify a module based on its spec."""
+    if spec is None:
+        return ModuleType.NOT_FOUND
+
+    if spec.origin == "built-in":
+        return ModuleType.BUILTIN
+
+    if spec.origin == "frozen":
+        return ModuleType.FROZEN
+
+    if name in _get_stdlib_names() or name in sys.builtin_module_names:
+        return ModuleType.STDLIB
+
+    origin = spec.origin or ""
+    stdlib_path = os.path.dirname(os.__file__)
+    if origin.startswith(stdlib_path):
+        return ModuleType.STDLIB
+
+    # Check if it's in a site-packages directory
+    for path_entry in sys.path:
+        if "site-packages" in path_entry and origin.startswith(path_entry):
+            return ModuleType.THIRD_PARTY
+
+    return ModuleType.LOCAL
+
+
+def _find_candidates_on_path(
+    name: str,
+    search_paths: List[str],
+) -> List[PathSearchEntry]:
+    """Walk sys.path and check each entry for the module."""
+    top_level = name.split(".")[0]
+    entries: List[PathSearchEntry] = []
+
+    for path_str in search_paths:
+        if not path_str:
+            path_str = os.getcwd()
+
+        path = Path(path_str)
+        if not path.is_dir():
+            entries.append(PathSearchEntry(
+                path=path_str,
+                result=SearchResult.SKIPPED,
+            ))
+            continue
+
+        # Check for package (directory with __init__.py)
+        pkg_init = path / top_level / "__init__.py"
+        if pkg_init.exists():
+            entries.append(PathSearchEntry(
+                path=path_str,
+                result=SearchResult.FOUND,
+                candidate=str(pkg_init),
+            ))
+            continue
+
+        # Check for single-file module
+        module_file = path / f"{top_level}.py"
+        if module_file.exists():
+            entries.append(PathSearchEntry(
+                path=path_str,
+                result=SearchResult.FOUND,
+                candidate=str(module_file),
+            ))
+            continue
+
+        # Check for compiled extensions
+        for ext in importlib.machinery.EXTENSION_SUFFIXES:
+            ext_file = path / f"{top_level}{ext}"
+            if ext_file.exists():
+                entries.append(PathSearchEntry(
+                    path=path_str,
+                    result=SearchResult.FOUND,
+                    candidate=str(ext_file),
+                ))
+                break
+        else:
+            entries.append(PathSearchEntry(
+                path=path_str,
+                result=SearchResult.NOT_FOUND,
+            ))
+
+    return entries
+
+
+def _detect_shadows(
+    name: str,
+    search_log: List[PathSearchEntry],
+    module_type: ModuleType,
+) -> List[ShadowWarning]:
+    """Detect if any earlier path entries shadow the resolved module."""
+    stdlib_names = _get_stdlib_names()
+    shadows: List[ShadowWarning] = []
+
+    found_entries = [e for e in search_log if e.result == SearchResult.FOUND]
+    if len(found_entries) <= 1:
+        return shadows
+
+    # The first FOUND entry is what Python actually uses.
+    # Any subsequent FOUND entries are being shadowed.
+    winner = found_entries[0]
+
+    top_level = name.split(".")[0]
+
+    # If a local file shadows a stdlib or third-party module
+    if top_level in stdlib_names:
+        winner_in_stdlib = False
+        stdlib_path = os.path.dirname(os.__file__)
+        if winner.candidate and stdlib_path in winner.candidate:
+            winner_in_stdlib = True
+
+        if not winner_in_stdlib:
+            shadows.append(ShadowWarning(
+                shadow_path=winner.candidate or "unknown",
+                shadowed_module=top_level,
+                description=f"'{winner.candidate}' shadows stdlib module '{top_level}'",
+            ))
+
+    # If multiple found, the first one shadows the rest
+    for other in found_entries[1:]:
+        if other.candidate and winner.candidate and other.candidate != winner.candidate:
+            # Check if the shadowed one is in site-packages (third-party)
+            if "site-packages" in (other.candidate or ""):
+                shadows.append(ShadowWarning(
+                    shadow_path=winner.candidate or "unknown",
+                    shadowed_module=top_level,
+                    description=(
+                        f"'{winner.candidate}' shadows installed package at '{other.candidate}'"
+                    ),
+                ))
+
+    return shadows
+
+
+def trace_import(
+    module_name: str,
+    *,
+    verbose: bool = False,
+) -> TraceReport:
+    """
+    Trace the import resolution for a module name.
+
+    Args:
+        module_name: The module to trace (e.g., "requests", "json", "os.path").
+        verbose: Include all sys.path entries in the search log.
+
+    Returns:
+        TraceReport with full resolution details.
+    """
+    # Check if already in sys.modules
+    is_cached = module_name in sys.modules
+
+    # Try to find the module spec without importing it
+    try:
+        spec = importlib.util.find_spec(module_name)
+    except (ModuleNotFoundError, ValueError):
+        spec = None
+
+    resolved_path: Optional[str] = None
+    is_package = False
+    submodule_of: Optional[str] = None
+
+    if spec is not None:
+        resolved_path = spec.origin
+        is_package = spec.submodule_search_locations is not None
+        if "." in module_name:
+            submodule_of = module_name.rsplit(".", 1)[0]
+
+    module_type = _classify_module(module_name, spec)
+
+    # Build the search log
+    search_log = _find_candidates_on_path(module_name, sys.path)
+
+    # Detect shadows
+    shadows = _detect_shadows(module_name, search_log, module_type)
+
+    # In non-verbose mode, only keep FOUND entries and the first few NOT_FOUND
+    if not verbose:
+        filtered: List[PathSearchEntry] = []
+        not_found_count = 0
+        for entry in search_log:
+            if entry.result == SearchResult.FOUND:
+                filtered.append(entry)
+            elif entry.result == SearchResult.NOT_FOUND and not_found_count < 3:
+                filtered.append(entry)
+                not_found_count += 1
+            elif entry.result == SearchResult.SKIPPED:
+                continue
+        search_log = filtered
+
+    return TraceReport(
+        module_name=module_name,
+        resolved_path=resolved_path,
+        module_type=module_type,
+        is_package=is_package,
+        is_cached=is_cached,
+        submodule_of=submodule_of,
+        search_log=search_log,
+        shadows=shadows,
+    )

--- a/tests/test_trace_formatter.py
+++ b/tests/test_trace_formatter.py
@@ -1,0 +1,36 @@
+"""Tests for the trace formatter."""
+
+from __future__ import annotations
+
+from pywho.trace_formatter import format_trace
+from pywho.tracer import trace_import
+
+
+class TestTraceFormatter:
+    """Test terminal formatting of trace reports."""
+
+    def test_format_contains_module_name(self) -> None:
+        report = trace_import("json")
+        output = format_trace(report)
+        assert "json" in output
+
+    def test_format_contains_resolved_path(self) -> None:
+        report = trace_import("os")
+        output = format_trace(report)
+        assert "Resolved to" in output
+
+    def test_format_not_found(self) -> None:
+        report = trace_import("nonexistent_xyz_99999")
+        output = format_trace(report)
+        assert "NOT FOUND" in output
+
+    def test_format_shows_search_order(self) -> None:
+        report = trace_import("json", verbose=True)
+        output = format_trace(report)
+        assert "Search order" in output
+
+    def test_format_returns_string(self) -> None:
+        report = trace_import("os")
+        output = format_trace(report)
+        assert isinstance(output, str)
+        assert len(output) > 50

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -1,0 +1,148 @@
+"""Tests for the import resolution tracer."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from pywho.tracer import (
+    ModuleType,
+    SearchResult,
+    TraceReport,
+    trace_import,
+)
+
+
+class TestTraceStdlib:
+    """Test tracing stdlib modules."""
+
+    def test_trace_os(self) -> None:
+        report = trace_import("os")
+        assert report.module_name == "os"
+        assert report.resolved_path is not None
+        assert report.module_type in (ModuleType.STDLIB, ModuleType.BUILTIN, ModuleType.FROZEN)
+
+    def test_trace_json(self) -> None:
+        report = trace_import("json")
+        assert report.module_name == "json"
+        assert report.resolved_path is not None
+        assert report.is_package is True
+
+    def test_trace_sys(self) -> None:
+        report = trace_import("sys")
+        assert report.module_name == "sys"
+        assert report.module_type == ModuleType.BUILTIN
+
+    def test_trace_os_path(self) -> None:
+        report = trace_import("os.path")
+        assert report.module_name == "os.path"
+        assert report.submodule_of == "os"
+
+    def test_trace_math(self) -> None:
+        report = trace_import("math")
+        assert report.module_name == "math"
+        assert report.resolved_path is not None
+
+
+class TestTraceThirdParty:
+    """Test tracing installed third-party packages."""
+
+    def test_trace_pytest(self) -> None:
+        report = trace_import("pytest")
+        assert report.module_name == "pytest"
+        assert report.resolved_path is not None
+        assert report.module_type == ModuleType.THIRD_PARTY
+        assert report.is_package is True
+
+    def test_trace_not_installed(self) -> None:
+        report = trace_import("nonexistent_module_xyz_12345")
+        assert report.module_type == ModuleType.NOT_FOUND
+        assert report.resolved_path is None
+
+
+class TestTraceShadows:
+    """Test shadow detection."""
+
+    def test_detects_stdlib_shadow(self, tmp_path: Path) -> None:
+        # Create a json.py in a temp directory
+        shadow_file = tmp_path / "json.py"
+        shadow_file.write_text("# shadow")
+
+        # Prepend tmp_path to sys.path
+        original_path = sys.path.copy()
+        sys.path.insert(0, str(tmp_path))
+        try:
+            report = trace_import("json")
+            # The search log should show the shadow found first
+            found = [e for e in report.search_log if e.result == SearchResult.FOUND]
+            assert len(found) >= 2
+            assert str(tmp_path) in found[0].path
+        finally:
+            sys.path[:] = original_path
+
+    def test_no_shadow_for_clean_module(self) -> None:
+        report = trace_import("os")
+        # os shouldn't have shadows in a normal environment
+        stdlib_shadows = [s for s in report.shadows if "shadows stdlib" in s.description]
+        assert len(stdlib_shadows) == 0
+
+
+class TestTraceSearchLog:
+    """Test the search log."""
+
+    def test_search_log_not_empty(self) -> None:
+        report = trace_import("os", verbose=True)
+        assert len(report.search_log) > 0
+
+    def test_verbose_includes_more_entries(self) -> None:
+        brief = trace_import("json")
+        verbose = trace_import("json", verbose=True)
+        assert len(verbose.search_log) >= len(brief.search_log)
+
+    def test_found_entry_has_candidate(self) -> None:
+        report = trace_import("json", verbose=True)
+        found = [e for e in report.search_log if e.result == SearchResult.FOUND]
+        assert len(found) >= 1
+        assert found[0].candidate is not None
+
+
+class TestTraceCached:
+    """Test cache detection."""
+
+    def test_cached_module(self) -> None:
+        # os is always in sys.modules
+        report = trace_import("os")
+        assert report.is_cached is True
+
+    def test_uncached_module(self) -> None:
+        # Remove a module from sys.modules temporarily
+        mod_name = "pywho.tracer"
+        original = sys.modules.pop(mod_name, None)
+        try:
+            report = trace_import(mod_name)
+            assert report.is_cached is False
+        finally:
+            if original is not None:
+                sys.modules[mod_name] = original
+
+
+class TestTraceReport:
+    """Test the TraceReport dataclass."""
+
+    def test_to_dict(self) -> None:
+        report = trace_import("os")
+        d = report.to_dict()
+        assert d["module_name"] == "os"
+        assert "resolved_path" in d
+        assert "module_type" in d
+        assert "search_log" in d
+        assert "shadows" in d
+
+    def test_to_dict_json_serializable(self) -> None:
+        report = trace_import("json", verbose=True)
+        d = report.to_dict()
+        json_str = json.dumps(d)
+        assert isinstance(json_str, str)


### PR DESCRIPTION
## Summary

- New `pywho trace <module>` subcommand that explains where an import resolves and why
- Shows sys.path search order, module type (stdlib/third-party/local/builtin), cache status
- Detects import shadows: warns when local files shadow stdlib or installed packages
- `trace_import()` Python API with `TraceReport` dataclass
- `--verbose` flag for full sys.path search log, `--json` for machine-readable output
- 21 new tests (53 total), updated README, docs, API reference, CHANGELOG
- Version bump to 0.2.0

## Test plan

- [x] 53 tests passing locally
- [x] CI passes on all 3 OSes x 5 Python versions
- [x] Smoke test: `pywho trace json`, `pywho trace pytest`, `pywho trace nonexistent`
- [x] Verify shadow detection with a local shadow file