### PR TITLE
ci: add pypi environment for trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    environment: pypi
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION
## Summary

- Add `environment: pypi` to the publish job in CI workflow
- Matches the trusted publisher config on PyPI (environment name: `pypi`)
- Created `pypi` environment on GitHub repo

This enables automatic PyPI publishing via trusted publishers when tags are pushed.