### PR TITLE
ci: fix Node.js 24 deprecation warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary

- Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` env var to suppress Node.js deprecation warnings in CI

## Test plan

- [ ] CI runs without Node.js deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)