### PR TITLE
ci: add Dependabot config and auto-merge workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps"

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,0 +1,28 @@
+name: Auto-merge Dependabot
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Approve PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Add `dependabot.yml` for weekly dependency updates (GitHub Actions + pip)
- Add `auto-merge-dependabot.yml` workflow that auto-approves and auto-merges Dependabot PRs once all 15 CI checks pass
- Enabled Dependabot vulnerability alerts and automated security fixes on the repo

## How it works

1. Dependabot opens a PR when a dependency update is available
2. CI runs all 15 test matrix jobs (3 OSes x 5 Python versions)
3. If all checks pass, the auto-merge workflow approves and squash-merges the PR automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)