### PR TITLE
chore: add contributing guide, templates, codecov, and topics

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug Report
+about: Report something that isn't working correctly
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## Describe the bug
+
+A clear description of what the bug is.
+
+## To reproduce
+
+Steps to reproduce the behavior:
+
+1. Run `pywho ...`
+2. See error
+
+## Expected behavior
+
+What you expected to happen.
+
+## Environment
+
+Paste the output of:
+
+```bash
+pywho --json
+```
+
+<details>
+<summary>pywho output</summary>
+
+```json
+PASTE OUTPUT HERE
+```
+
+</details>
+
+## Additional context
+
+Any other context about the problem (screenshots, logs, etc).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+
+What problem does this feature solve? What's the use case?
+
+## Proposed solution
+
+Describe the feature you'd like to see.
+
+## Alternatives considered
+
+Any alternative solutions or workarounds you've considered.
+
+## Additional context
+
+Any other context, mockups, or examples.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## What does this PR do?
+
+<!-- Brief description of the change -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation update
+- [ ] CI/infrastructure
+- [ ] Refactoring (no behavior change)
+
+## Checklist
+
+- [ ] Tests pass (`pytest -v`)
+- [ ] Type check passes (`mypy src/pywho`)
+- [ ] Linting passes (`ruff check src/ tests/`)
+- [ ] Documentation updated (if user-facing changes)
+- [ ] Changelog updated (if user-facing changes)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,14 @@ jobs:
         run: uv pip install --system -e ".[dev]"
 
       - name: Run tests
-        run: pytest -v
+        run: pytest -v --cov=pywho --cov-report=xml
+
+      - name: Upload coverage
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.xml
+          fail_ci_on_error: false
 
       - name: Type check
         run: mypy src/pywho

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,99 +1,67 @@
 # Contributing to pywho
 
-Thanks for your interest in contributing to pywho! This document provides guidelines and instructions for contributing.
+Thanks for your interest in contributing! Here's how to get started.
 
 ## Development setup
-
-1. Fork and clone the repository:
 
 ```bash
 git clone https://github.com/YOUR_USERNAME/pywho.git
 cd pywho
-```
-
-2. Create a virtual environment and install dependencies:
-
-```bash
-uv venv
-source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+uv venv && source .venv/bin/activate  # Windows: .venv\Scripts\activate
 uv pip install -e ".[dev]"
-```
-
-3. Install pre-commit hooks:
-
-```bash
-pip install pre-commit
 pre-commit install
 ```
 
-## Running tests
+## Running checks
 
 ```bash
-# Run all tests
-make test
-
-# Run with verbose output
-pytest -v
-
-# Run a specific test
-pytest tests/test_inspector.py::TestVenvDetection -v
+pytest -v          # Run tests
+mypy src/pywho     # Type check
+ruff check src/ tests/   # Lint
+ruff format src/ tests/  # Format
 ```
 
-## Code quality
+Or use the Makefile shortcuts:
 
 ```bash
-# Run linter
-make lint
-
-# Auto-format code
-make format
-
-# Run type checker
-make typecheck
-
-# Run everything
-make all
+make test       # Tests
+make typecheck  # mypy
+make lint       # ruff check
+make format     # ruff format
+make all        # Everything
 ```
 
 ## Making changes
 
-1. Create a branch for your change:
+1. Fork the repo and create a feature branch from `main`
+2. Make your changes
+3. Add or update tests as needed
+4. Ensure all checks pass
+5. Commit using [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `docs:`, `test:`, `chore:`
+6. Open a pull request against `main`
 
-```bash
-git checkout -b your-feature-name
-```
+## Pull request guidelines
 
-2. Make your changes and ensure:
-   - All tests pass (`make test`)
-   - Code is formatted (`make format`)
-   - Linter passes (`make lint`)
-   - Type checker passes (`make typecheck`)
-
-3. Commit your changes with a clear message:
-
-```bash
-git commit -m "feat: add support for ..."
-```
-
-We follow [Conventional Commits](https://www.conventionalcommits.org/):
-- `feat:` for new features
-- `fix:` for bug fixes
-- `docs:` for documentation changes
-- `test:` for test additions/changes
-- `chore:` for maintenance tasks
-
-4. Push and open a pull request.
+- Keep PRs focused — one feature or fix per PR
+- Add tests for new functionality
+- Update documentation if you're changing user-facing behavior
+- Update `CHANGELOG.md` for user-facing changes
 
 ## Adding support for a new venv type
-
-To add detection for a new virtual environment manager:
 
 1. Add detection logic in `src/pywho/inspector.py` in the `_detect_venv()` function
 2. Add the type string to the `VenvInfo.type` field documentation
 3. Add a test in `tests/test_inspector.py`
 4. Update the README table
 
-## Reporting issues
+## Reporting bugs
 
-- Use the [GitHub issue tracker](https://github.com/AhsanSheraz/pywho/issues)
-- Include the output of `pywho --json` when reporting environment-related issues
+Use the [bug report template](https://github.com/AhsanSheraz/pywho/issues/new?template=bug_report.md) and include the output of `pywho --json`.
+
+## Suggesting features
+
+Open an issue using the [feature request template](https://github.com/AhsanSheraz/pywho/issues/new?template=feature_request.md).
+
+## Code of conduct
+
+Be respectful, constructive, and welcoming. We're all here to make Python debugging easier.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   <a href="https://pypi.org/project/pywho/"><img src="https://img.shields.io/pypi/pyversions/pywho.svg" alt="Python versions"></a>
   <a href="https://github.com/AhsanSheraz/pywho/blob/main/LICENSE"><img src="https://img.shields.io/pypi/l/pywho.svg" alt="License"></a>
   <a href="https://pypi.org/project/pywho/"><img src="https://img.shields.io/pypi/dm/pywho.svg" alt="Downloads"></a>
+  <a href="https://codecov.io/gh/AhsanSheraz/pywho"><img src="https://codecov.io/gh/AhsanSheraz/pywho/branch/main/graph/badge.svg" alt="Coverage"></a>
 </p>
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ include = ["src/pywho", "README.md", "LICENSE", "CHANGELOG.md"]
 [project.optional-dependencies]
 dev = [
     "pytest>=7.0",
+    "pytest-cov>=4.0",
     "mypy>=1.0",
 ]
 


### PR DESCRIPTION
## Summary

- Add `CONTRIBUTING.md` with dev setup, guidelines, and conventional commits reference
- Add GitHub issue templates (bug report + feature request) with structured forms
- Add pull request template with type-of-change checklist
- Add Codecov integration for test coverage reporting + badge in README
- Add `pytest-cov` to dev dependencies
- Add GitHub topics for repo discoverability: python, cli, debugging, developer-tools, etc.

## Test plan

- [x] All existing tests still pass
- [x] CI passes with new coverage upload step
- [x] Codecov badge will show once first coverage report uploads

🤖 Generated with [Claude Code](https://claude.com/claude-code)