### PR TITLE
ci: fix codecov token and auto-merge for workflow PRs

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -21,8 +21,10 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Note: PRs that modify .github/workflows/ files cannot be auto-merged
+      # with GITHUB_TOKEN due to GitHub security restrictions. Those need manual merge.
       - name: Enable auto-merge
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL" || echo "Auto-merge not available for this PR (may modify workflow files)"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,8 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: coverage.xml
-          fail_ci_on_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
       - name: Type check
         run: mypy src/pywho


### PR DESCRIPTION
## Summary

- Add `CODECOV_TOKEN` secret reference for coverage upload (tokenless upload not supported)
- Fix parameter name: `fail_ci_if_error` (was `fail_ci_on_error`)
- Gracefully handle auto-merge failure for Dependabot PRs that modify workflow files (GitHub security restriction)

## Test plan

- [ ] CI passes
- [ ] Codecov upload works once token is added as repo secret