### PR TITLE
ci: fix codecov upload and update docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,11 @@ jobs:
 
       - name: Upload coverage
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v5.5.2
         with:
           files: coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: false
           fail_ci_if_error: false
 
       - name: Type check

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,3 +50,5 @@ pywho
 - Site-packages locations
 - JSON output for CI/scripting
 - Installed package listing
+- Import tracing (`pywho trace <module>`)
+- Project-wide shadow scanning (`pywho scan .`)


### PR DESCRIPTION
## Summary

- Pin codecov-action to v5.5.2 for Node.js 24 compatibility
- Disable OIDC to use explicit CODECOV_TOKEN for protected branches
- Update docs index with trace and scan features