### PR TITLE
ci: replace codecov action with CLI to fix Node.js 20 warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,9 @@ jobs:
 
       - name: Upload coverage
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
-        uses: codecov/codecov-action@v5.5.2
-        with:
-          files: coverage.xml
-          token: ${{ secrets.CODECOV_TOKEN }}
-          use_oidc: false
-          fail_ci_if_error: false
+        run: |
+          pip install codecov-cli
+          codecovcli upload-process --token ${{ secrets.CODECOV_TOKEN }} --file coverage.xml --git-service github
 
       - name: Type check
         run: mypy src/pywho


### PR DESCRIPTION
## Summary

- Replace `codecov/codecov-action@v5` with `codecov-cli` (pip package)
- Eliminates the Node.js 20 deprecation warning caused by codecov action's internal `actions/github-script` dependency
- Zero Node.js dependency — pure Python CLI upload