### PR TITLE
ci: use official codecov actions for coverage uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         run: uv pip install --system -e ".[dev]"
 
       - name: Run tests with coverage
-        run: pytest -v --cov=pywho --cov-branch --cov-report=xml --cov-fail-under=95
+        run: pytest -v --cov=pywho --cov-branch --cov-report=xml --junitxml=junit.xml --cov-fail-under=95
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,12 +54,18 @@ jobs:
         run: uv pip install --system -e ".[dev]"
 
       - name: Run tests with coverage
-        run: pytest -v --cov=pywho --cov-report=xml --cov-fail-under=95
+        run: pytest -v --cov=pywho --cov-branch --cov-report=xml --cov-fail-under=95
 
-      - name: Upload coverage
-        run: |
-          pip install codecov-cli
-          codecovcli upload-process --token ${{ secrets.CODECOV_TOKEN }} --file coverage.xml --git-service github
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Replace `codecov-cli` with official `codecov/codecov-action@v5` for coverage uploads
- Add `codecov/test-results-action@v1` for test result reporting
- Enable branch coverage with `--cov-branch`
- Fixes the "unknown" codecov badge on README

## Test plan
- [ ] CI passes with the new codecov actions
- [ ] Codecov badge updates from "unknown" to actual coverage percentage

🤖 Generated with [Claude Code](https://claude.com/claude-code)