### PR TITLE
test: improve branch coverage from 94% to 98%

### DIFF
--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -64,6 +64,32 @@ class TestFormatterVenvBranches:
         assert "No" in output
         assert "Base Prefix" not in output
 
+    def test_format_active_venv_with_path_no_prompt(self) -> None:
+        report = EnvironmentReport(
+            executable="/usr/bin/python3",
+            version="3.12.0",
+            version_info="3.12.0",
+            implementation="CPython",
+            compiler="GCC",
+            architecture="64-bit",
+            build_date="",
+            platform_system="Linux",
+            platform_release="6.0",
+            platform_machine="x86_64",
+            venv=VenvInfo(is_active=True, type="venv", path="/home/user/.venv", prompt=None),
+            prefix="/home/user/.venv",
+            base_prefix="/usr",
+            exec_prefix="/usr",
+            sys_path=[],
+            site_packages=[],
+            package_manager="pip",
+            pip_version="24.0",
+            packages=[],
+        )
+        output = format_report(report)
+        assert "Path" in output
+        assert "Prompt" not in output
+
     def test_format_active_venv_without_path_and_prompt(self) -> None:
         report = EnvironmentReport(
             executable="/usr/bin/python3",

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -158,6 +158,36 @@ class TestVenvDetection:
             assert venv.type == "uv"
             assert venv.prompt == "myproject"
 
+    def test_uv_venv_with_empty_prompt(self, tmp_path: Path) -> None:
+        fake_prefix = str(tmp_path / "uvvenv2")
+        (tmp_path / "uvvenv2").mkdir()
+        cfg_text = "home = /usr/bin\nuv = 0.1.0\nprompt = \n"
+        (tmp_path / "uvvenv2" / "pyvenv.cfg").write_text(cfg_text)
+
+        env_clean = {k: v for k, v in os.environ.items()
+                     if k not in ("CONDA_DEFAULT_ENV", "PIPENV_ACTIVE", "POETRY_ACTIVE")}
+        with patch.dict(os.environ, env_clean, clear=True), \
+             patch.object(sys, "prefix", fake_prefix), \
+             patch.object(sys, "base_prefix", "/usr"):
+            venv = _detect_venv()
+            assert venv.type == "uv"
+            assert venv.prompt == "uvvenv2"
+
+    def test_win32_orig_prefix_path(self, tmp_path: Path) -> None:
+        fake_prefix = str(tmp_path / "winvenv2")
+        win_lib = tmp_path / "winvenv2" / "Lib"
+        win_lib.mkdir(parents=True)
+        (win_lib / "orig-prefix.txt").write_text("C:\\Python312")
+
+        env_clean = {k: v for k, v in os.environ.items()
+                     if k not in ("CONDA_DEFAULT_ENV", "PIPENV_ACTIVE", "POETRY_ACTIVE")}
+        with patch.dict(os.environ, env_clean, clear=True), \
+             patch.object(sys, "prefix", fake_prefix), \
+             patch.object(sys, "base_prefix", "C:\\Python312"), \
+             patch.object(sys, "platform", "win32"):
+            venv = _detect_venv()
+            assert venv.type == "virtualenv"
+
     def test_poetry_venv_detection(self, tmp_path: Path) -> None:
         fake_prefix = str(tmp_path / "poetryvenv")
         (tmp_path / "poetryvenv").mkdir()
@@ -266,6 +296,16 @@ class TestPackageManager:
              patch.object(sys, "prefix", str(tmp_path)):
             assert _detect_package_manager() == "uv"
 
+    def test_cfg_exists_but_no_uv(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "pyvenv.cfg"
+        cfg.write_text("home = /usr/bin\n")
+        env = {k: v for k, v in os.environ.items()
+               if k not in ("CONDA_DEFAULT_ENV", "PIPENV_ACTIVE", "POETRY_ACTIVE")}
+        with patch.dict(os.environ, env, clear=True), \
+             patch.object(sys, "prefix", str(tmp_path)), \
+             patch.object(sys, "executable", "/usr/bin/python"):
+            assert _detect_package_manager() == "pip"
+
     def test_uv_manager_cfg_read_error(self, tmp_path: Path) -> None:
         cfg = tmp_path / "pyvenv.cfg"
         cfg.write_text("uv = 0.5\n")
@@ -298,6 +338,17 @@ class TestPipVersion:
         mock_result = MagicMock()
         mock_result.returncode = 1
         with patch("pywho.inspector.subprocess.run", return_value=mock_result):
+            assert _get_pip_version() is None
+
+    def test_short_output_returns_none(self) -> None:
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "pip"
+        with patch("pywho.inspector.subprocess.run", return_value=mock_result):
+            assert _get_pip_version() is None
+
+    def test_oserror_returns_none(self) -> None:
+        with patch("pywho.inspector.subprocess.run", side_effect=OSError("fail")):
             assert _get_pip_version() is None
 
 

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 from pywho.scanner import (
     Severity,
@@ -179,6 +180,53 @@ class TestIsInstalledPackage:
 
     def test_builtin_module_not_detected(self) -> None:
         assert _is_installed_package("sys") is False
+
+    def test_value_error_returns_false(self) -> None:
+        with patch("pywho.scanner.importlib.util.find_spec", side_effect=ValueError("bad")):
+            assert _is_installed_package("badmod") is False
+
+    def test_frozen_module_not_detected(self) -> None:
+        mock_spec = MagicMock()
+        mock_spec.origin = "frozen"
+        with patch("pywho.scanner.importlib.util.find_spec", return_value=mock_spec):
+            assert _is_installed_package("_frozen") is False
+
+
+class TestScanPathOptions:
+    """Test scan_path with custom options."""
+
+    def test_custom_exclude_dirs(self, tmp_path: Path) -> None:
+        mydir = tmp_path / "custom"
+        mydir.mkdir()
+        (mydir / "math.py").write_text("")
+        results = scan_path(
+            tmp_path,
+            check_installed=False,
+            exclude_dirs={"custom"},
+        )
+        assert len(results) == 0
+
+    def test_custom_ignore_names(self, tmp_path: Path) -> None:
+        (tmp_path / "math.py").write_text("")
+        results = scan_path(
+            tmp_path,
+            check_installed=False,
+            ignore_names={"math"},
+        )
+        assert len(results) == 0
+
+    def test_egg_info_dirs_excluded(self, tmp_path: Path) -> None:
+        egg_dir = tmp_path / "mypackage.egg-info"
+        egg_dir.mkdir()
+        (egg_dir / "math.py").write_text("")
+        results = scan_path(tmp_path, check_installed=False)
+        assert len(results) == 0
+
+    def test_underscore_prefix_skipped(self, tmp_path: Path) -> None:
+        (tmp_path / "_thread.py").write_text("")
+        results = scan_path(tmp_path, check_installed=False)
+        # _thread is in stdlib so it should be detected (it's an exception)
+        assert any(r.module_name == "_thread" for r in results)
 
 
 class TestInstalledPackageShadow:

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -223,10 +223,12 @@ class TestScanPathOptions:
         assert len(results) == 0
 
     def test_underscore_prefix_skipped(self, tmp_path: Path) -> None:
-        (tmp_path / "_thread.py").write_text("")
+        (tmp_path / "_myhelper.py").write_text("")
+        (tmp_path / "math.py").write_text("")
         results = scan_path(tmp_path, check_installed=False)
-        # _thread is in stdlib so it should be detected (it's an exception)
-        assert any(r.module_name == "_thread" for r in results)
+        names = {r.module_name for r in results}
+        assert "_myhelper" not in names
+        assert "math" in names
 
 
 class TestInstalledPackageShadow:

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
@@ -11,8 +12,10 @@ from pywho.tracer import (
     ModuleType,
     PathSearchEntry,
     SearchResult,
+    ShadowWarning,
     _classify_module,
     _detect_shadows,
+    _find_candidates_on_path,
     trace_import,
 )
 
@@ -193,7 +196,87 @@ class TestDetectShadows:
         shadows = _detect_shadows("requests", log, ModuleType.LOCAL)
         assert len(shadows) >= 1
 
+    def test_stdlib_winner_not_flagged(self) -> None:
+        stdlib_path = os.path.dirname(os.__file__)
+        log = [
+            PathSearchEntry(
+                path=stdlib_path,
+                result=SearchResult.FOUND,
+                candidate=f"{stdlib_path}/json/__init__.py",
+            ),
+            PathSearchEntry(
+                path="/other",
+                result=SearchResult.FOUND,
+                candidate="/other/json.py",
+            ),
+        ]
+        shadows = _detect_shadows("json", log, ModuleType.STDLIB)
+        stdlib_shadows = [s for s in shadows if "shadows stdlib" in s.description]
+        assert len(stdlib_shadows) == 0
+
+    def test_shadow_with_none_candidates(self) -> None:
+        log = [
+            PathSearchEntry(
+                path="/a",
+                result=SearchResult.FOUND,
+                candidate=None,
+            ),
+            PathSearchEntry(
+                path="/b",
+                result=SearchResult.FOUND,
+                candidate=None,
+            ),
+        ]
+        shadows = _detect_shadows("requests", log, ModuleType.LOCAL)
+        assert isinstance(shadows, list)
+
     def test_find_spec_value_error(self) -> None:
         with patch("pywho.tracer.importlib.util.find_spec", side_effect=ValueError("bad")):
             report = trace_import("some.bad.module")
             assert report.module_type == ModuleType.NOT_FOUND
+
+
+class TestFindCandidates:
+    """Test path search candidate finding."""
+
+    def test_nondir_path_is_skipped(self, tmp_path: Path) -> None:
+        fake_path = str(tmp_path / "nonexistent")
+        entries = _find_candidates_on_path("os", [fake_path])
+        assert len(entries) == 1
+        assert entries[0].result == SearchResult.SKIPPED
+
+    def test_empty_string_uses_cwd(self, tmp_path: Path) -> None:
+        entries = _find_candidates_on_path("nonexistent_xyz_999", [""])
+        assert len(entries) == 1
+        assert entries[0].result == SearchResult.NOT_FOUND
+
+    def test_finds_extension_module(self, tmp_path: Path) -> None:
+        import importlib.machinery
+        if importlib.machinery.EXTENSION_SUFFIXES:
+            ext = importlib.machinery.EXTENSION_SUFFIXES[0]
+            (tmp_path / f"fakemod{ext}").write_text("")
+            entries = _find_candidates_on_path("fakemod", [str(tmp_path)])
+            assert any(e.result == SearchResult.FOUND for e in entries)
+
+
+class TestClassifyModuleBranches:
+    """Test additional classify branches."""
+
+    def test_classify_none_spec(self) -> None:
+        assert _classify_module("anything", None) == ModuleType.NOT_FOUND
+
+    def test_classify_dist_packages(self) -> None:
+        spec = MagicMock()
+        spec.origin = "/usr/lib/python3/dist-packages/something/__init__.py"
+        assert _classify_module("something", spec) == ModuleType.THIRD_PARTY
+
+    def test_classify_local_module(self) -> None:
+        spec = MagicMock()
+        spec.origin = "/home/user/project/mymod.py"
+        assert _classify_module("mymod", spec) == ModuleType.LOCAL
+
+    def test_classify_stdlib_by_path(self) -> None:
+        stdlib_path = os.path.dirname(os.__file__)
+        spec = MagicMock()
+        spec.origin = f"{stdlib_path}/somethingweird.py"
+        assert _classify_module("somethingweird", spec) == ModuleType.STDLIB

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -12,7 +12,6 @@ from pywho.tracer import (
     ModuleType,
     PathSearchEntry,
     SearchResult,
-    ShadowWarning,
     _classify_module,
     _detect_shadows,
     _find_candidates_on_path,


### PR DESCRIPTION
## Summary
- Add 21 new tests covering previously untested code branches
- Branch coverage improved from 94.02% to 97.79%
- Total tests: 149 (up from 128)

## Key areas covered
- pip version detection edge cases
- win32 platform virtualenv path
- Empty/missing venv prompt values  
- Package manager detection with pyvenv.cfg but no uv
- Tracer path candidate finding (non-dir, empty string, extensions)
- Module classification branches (None spec, dist-packages, local, stdlib by path)
- Shadow detection with stdlib winner and None candidates
- Scanner ValueError handling, frozen modules, custom options

## Test plan
- [x] All 149 tests pass locally
- [x] Branch coverage at 97.79%, above 95% threshold
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)