### PR TITLE
style: apply ruff format to all source and test files

### DIFF
--- a/src/pywho/cli.py
+++ b/src/pywho/cli.py
@@ -78,7 +78,8 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output as JSON (for scripting, CI, or sharing).",
     )
     parser.add_argument(
-        "--packages", "-p",
+        "--packages",
+        "-p",
         action="store_true",
         help="Include list of all installed packages.",
     )
@@ -88,7 +89,8 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Skip pip version detection (faster).",
     )
     parser.add_argument(
-        "--version", "-v",
+        "--version",
+        "-v",
         action="version",
         version=f"pywho {__version__}",
     )

--- a/src/pywho/inspector.py
+++ b/src/pywho/inspector.py
@@ -144,7 +144,8 @@ def _detect_venv() -> VenvInfo:
         orig_prefix_file = Path(venv_path) / "Lib" / "orig-prefix.txt"
     else:
         orig_prefix_file = (
-            Path(venv_path) / "lib"
+            Path(venv_path)
+            / "lib"
             / f"python{sys.version_info.major}.{sys.version_info.minor}"
             / "orig-prefix.txt"
         )

--- a/src/pywho/scanner.py
+++ b/src/pywho/scanner.py
@@ -39,39 +39,150 @@ def _get_stdlib_names() -> set[str]:
         return set(sys.stdlib_module_names)
     # Fallback for 3.9
     return {
-        "abc", "argparse", "ast", "asyncio", "base64", "bisect", "builtins",
-        "calendar", "cmath", "cmd", "code", "codecs", "collections",
-        "configparser", "contextlib", "copy", "csv", "ctypes", "dataclasses",
-        "datetime", "decimal", "difflib", "dis", "email", "enum", "errno",
-        "fnmatch", "fractions", "ftplib", "functools", "gc", "getpass",
-        "glob", "gzip", "hashlib", "heapq", "hmac", "html", "http",
-        "importlib", "inspect", "io", "itertools", "json", "keyword",
-        "linecache", "locale", "logging", "lzma", "math", "mimetypes",
-        "multiprocessing", "numbers", "operator", "os", "pathlib", "pdb",
-        "pickle", "platform", "pprint", "profile", "pstats", "queue",
-        "random", "re", "readline", "reprlib", "resource", "sched",
-        "secrets", "select", "shelve", "shlex", "shutil", "signal",
-        "site", "smtplib", "socket", "socketserver", "sqlite3", "ssl",
-        "stat", "statistics", "string", "struct", "subprocess", "sys",
-        "sysconfig", "tarfile", "tempfile", "textwrap", "threading",
-        "time", "timeit", "token", "tokenize", "traceback", "types",
-        "typing", "unicodedata", "unittest", "urllib", "uuid", "venv",
-        "warnings", "weakref", "webbrowser", "xml", "xmlrpc", "zipfile",
-        "zipimport", "zlib",
+        "abc",
+        "argparse",
+        "ast",
+        "asyncio",
+        "base64",
+        "bisect",
+        "builtins",
+        "calendar",
+        "cmath",
+        "cmd",
+        "code",
+        "codecs",
+        "collections",
+        "configparser",
+        "contextlib",
+        "copy",
+        "csv",
+        "ctypes",
+        "dataclasses",
+        "datetime",
+        "decimal",
+        "difflib",
+        "dis",
+        "email",
+        "enum",
+        "errno",
+        "fnmatch",
+        "fractions",
+        "ftplib",
+        "functools",
+        "gc",
+        "getpass",
+        "glob",
+        "gzip",
+        "hashlib",
+        "heapq",
+        "hmac",
+        "html",
+        "http",
+        "importlib",
+        "inspect",
+        "io",
+        "itertools",
+        "json",
+        "keyword",
+        "linecache",
+        "locale",
+        "logging",
+        "lzma",
+        "math",
+        "mimetypes",
+        "multiprocessing",
+        "numbers",
+        "operator",
+        "os",
+        "pathlib",
+        "pdb",
+        "pickle",
+        "platform",
+        "pprint",
+        "profile",
+        "pstats",
+        "queue",
+        "random",
+        "re",
+        "readline",
+        "reprlib",
+        "resource",
+        "sched",
+        "secrets",
+        "select",
+        "shelve",
+        "shlex",
+        "shutil",
+        "signal",
+        "site",
+        "smtplib",
+        "socket",
+        "socketserver",
+        "sqlite3",
+        "ssl",
+        "stat",
+        "statistics",
+        "string",
+        "struct",
+        "subprocess",
+        "sys",
+        "sysconfig",
+        "tarfile",
+        "tempfile",
+        "textwrap",
+        "threading",
+        "time",
+        "timeit",
+        "token",
+        "tokenize",
+        "traceback",
+        "types",
+        "typing",
+        "unicodedata",
+        "unittest",
+        "urllib",
+        "uuid",
+        "venv",
+        "warnings",
+        "weakref",
+        "webbrowser",
+        "xml",
+        "xmlrpc",
+        "zipfile",
+        "zipimport",
+        "zlib",
     }
 
 
 # Files that are common project files, not intended as importable modules
 _IGNORE_NAMES: set[str] = {
-    "setup", "conftest", "manage", "__init__", "__main__",
+    "setup",
+    "conftest",
+    "manage",
+    "__init__",
+    "__main__",
 }
 
 # Directories to skip during scanning
 _EXCLUDE_DIRS: set[str] = {
-    ".git", ".hg", ".svn", "__pycache__", ".tox", ".nox",
-    ".mypy_cache", ".pytest_cache", "node_modules", ".venv",
-    "venv", "env", ".env", "site-packages", ".eggs", "dist",
-    "build", ".ruff_cache",
+    ".git",
+    ".hg",
+    ".svn",
+    "__pycache__",
+    ".tox",
+    ".nox",
+    ".mypy_cache",
+    ".pytest_cache",
+    "node_modules",
+    ".venv",
+    "venv",
+    "env",
+    ".env",
+    "site-packages",
+    ".eggs",
+    "dist",
+    "build",
+    ".ruff_cache",
 }
 
 
@@ -96,10 +207,7 @@ def _walk_python_files(root: Path, exclude_dirs: set[str]) -> list[Path]:
     """Walk directory tree yielding .py files, respecting exclusions."""
     files: list[Path] = []
     for dirpath, dirnames, filenames in os.walk(root):
-        dirnames[:] = [
-            d for d in dirnames
-            if d not in exclude_dirs and not d.endswith(".egg-info")
-        ]
+        dirnames[:] = [d for d in dirnames if d not in exclude_dirs and not d.endswith(".egg-info")]
         for fname in filenames:
             if fname.endswith(".py"):
                 files.append(Path(dirpath) / fname)
@@ -151,19 +259,23 @@ def scan_path(
             continue
 
         if module_name in stdlib:
-            results.append(ShadowResult(
-                path=filepath,
-                module_name=module_name,
-                shadows="stdlib",
-                severity=Severity.HIGH,
-            ))
+            results.append(
+                ShadowResult(
+                    path=filepath,
+                    module_name=module_name,
+                    shadows="stdlib",
+                    severity=Severity.HIGH,
+                )
+            )
         elif check_installed and _is_installed_package(module_name):
-            results.append(ShadowResult(
-                path=filepath,
-                module_name=module_name,
-                shadows=f"installed:{module_name}",
-                severity=Severity.MEDIUM,
-            ))
+            results.append(
+                ShadowResult(
+                    path=filepath,
+                    module_name=module_name,
+                    shadows=f"installed:{module_name}",
+                    severity=Severity.MEDIUM,
+                )
+            )
 
     results.sort(key=lambda r: (r.severity.value, r.module_name))
     return results

--- a/src/pywho/tracer.py
+++ b/src/pywho/tracer.py
@@ -94,25 +94,118 @@ def _get_stdlib_names() -> set[str]:
         return set(sys.stdlib_module_names)
     # Fallback for 3.9
     return {
-        "abc", "argparse", "ast", "asyncio", "base64", "bisect", "builtins",
-        "calendar", "cmath", "cmd", "code", "codecs", "collections",
-        "configparser", "contextlib", "copy", "csv", "ctypes", "dataclasses",
-        "datetime", "decimal", "difflib", "dis", "email", "enum", "errno",
-        "fnmatch", "fractions", "ftplib", "functools", "gc", "getpass",
-        "glob", "gzip", "hashlib", "heapq", "hmac", "html", "http",
-        "importlib", "inspect", "io", "itertools", "json", "keyword",
-        "linecache", "locale", "logging", "lzma", "math", "mimetypes",
-        "multiprocessing", "numbers", "operator", "os", "pathlib", "pdb",
-        "pickle", "platform", "pprint", "profile", "pstats", "queue",
-        "random", "re", "readline", "reprlib", "resource", "sched",
-        "secrets", "select", "shelve", "shlex", "shutil", "signal",
-        "site", "smtplib", "socket", "socketserver", "sqlite3", "ssl",
-        "stat", "statistics", "string", "struct", "subprocess", "sys",
-        "sysconfig", "tarfile", "tempfile", "textwrap", "threading",
-        "time", "timeit", "token", "tokenize", "traceback", "types",
-        "typing", "unicodedata", "unittest", "urllib", "uuid", "venv",
-        "warnings", "weakref", "webbrowser", "xml", "xmlrpc", "zipfile",
-        "zipimport", "zlib",
+        "abc",
+        "argparse",
+        "ast",
+        "asyncio",
+        "base64",
+        "bisect",
+        "builtins",
+        "calendar",
+        "cmath",
+        "cmd",
+        "code",
+        "codecs",
+        "collections",
+        "configparser",
+        "contextlib",
+        "copy",
+        "csv",
+        "ctypes",
+        "dataclasses",
+        "datetime",
+        "decimal",
+        "difflib",
+        "dis",
+        "email",
+        "enum",
+        "errno",
+        "fnmatch",
+        "fractions",
+        "ftplib",
+        "functools",
+        "gc",
+        "getpass",
+        "glob",
+        "gzip",
+        "hashlib",
+        "heapq",
+        "hmac",
+        "html",
+        "http",
+        "importlib",
+        "inspect",
+        "io",
+        "itertools",
+        "json",
+        "keyword",
+        "linecache",
+        "locale",
+        "logging",
+        "lzma",
+        "math",
+        "mimetypes",
+        "multiprocessing",
+        "numbers",
+        "operator",
+        "os",
+        "pathlib",
+        "pdb",
+        "pickle",
+        "platform",
+        "pprint",
+        "profile",
+        "pstats",
+        "queue",
+        "random",
+        "re",
+        "readline",
+        "reprlib",
+        "resource",
+        "sched",
+        "secrets",
+        "select",
+        "shelve",
+        "shlex",
+        "shutil",
+        "signal",
+        "site",
+        "smtplib",
+        "socket",
+        "socketserver",
+        "sqlite3",
+        "ssl",
+        "stat",
+        "statistics",
+        "string",
+        "struct",
+        "subprocess",
+        "sys",
+        "sysconfig",
+        "tarfile",
+        "tempfile",
+        "textwrap",
+        "threading",
+        "time",
+        "timeit",
+        "token",
+        "tokenize",
+        "traceback",
+        "types",
+        "typing",
+        "unicodedata",
+        "unittest",
+        "urllib",
+        "uuid",
+        "venv",
+        "warnings",
+        "weakref",
+        "webbrowser",
+        "xml",
+        "xmlrpc",
+        "zipfile",
+        "zipimport",
+        "zlib",
     }
 
 
@@ -161,47 +254,57 @@ def _find_candidates_on_path(
 
         path = Path(path_str)
         if not path.is_dir():
-            entries.append(PathSearchEntry(
-                path=path_str,
-                result=SearchResult.SKIPPED,
-            ))
+            entries.append(
+                PathSearchEntry(
+                    path=path_str,
+                    result=SearchResult.SKIPPED,
+                )
+            )
             continue
 
         # Check for package (directory with __init__.py)
         pkg_init = path / top_level / "__init__.py"
         if pkg_init.exists():
-            entries.append(PathSearchEntry(
-                path=path_str,
-                result=SearchResult.FOUND,
-                candidate=str(pkg_init),
-            ))
+            entries.append(
+                PathSearchEntry(
+                    path=path_str,
+                    result=SearchResult.FOUND,
+                    candidate=str(pkg_init),
+                )
+            )
             continue
 
         # Check for single-file module
         module_file = path / f"{top_level}.py"
         if module_file.exists():
-            entries.append(PathSearchEntry(
-                path=path_str,
-                result=SearchResult.FOUND,
-                candidate=str(module_file),
-            ))
+            entries.append(
+                PathSearchEntry(
+                    path=path_str,
+                    result=SearchResult.FOUND,
+                    candidate=str(module_file),
+                )
+            )
             continue
 
         # Check for compiled extensions
         for ext in importlib.machinery.EXTENSION_SUFFIXES:
             ext_file = path / f"{top_level}{ext}"
             if ext_file.exists():
-                entries.append(PathSearchEntry(
-                    path=path_str,
-                    result=SearchResult.FOUND,
-                    candidate=str(ext_file),
-                ))
+                entries.append(
+                    PathSearchEntry(
+                        path=path_str,
+                        result=SearchResult.FOUND,
+                        candidate=str(ext_file),
+                    )
+                )
                 break
         else:
-            entries.append(PathSearchEntry(
-                path=path_str,
-                result=SearchResult.NOT_FOUND,
-            ))
+            entries.append(
+                PathSearchEntry(
+                    path=path_str,
+                    result=SearchResult.NOT_FOUND,
+                )
+            )
 
     return entries
 
@@ -233,11 +336,13 @@ def _detect_shadows(
             winner_in_stdlib = True
 
         if not winner_in_stdlib:
-            shadows.append(ShadowWarning(
-                shadow_path=winner.candidate or "unknown",
-                shadowed_module=top_level,
-                description=f"'{winner.candidate}' shadows stdlib module '{top_level}'",
-            ))
+            shadows.append(
+                ShadowWarning(
+                    shadow_path=winner.candidate or "unknown",
+                    shadowed_module=top_level,
+                    description=f"'{winner.candidate}' shadows stdlib module '{top_level}'",
+                )
+            )
 
     # If multiple found, the first one shadows the rest
     for other in found_entries[1:]:
@@ -247,13 +352,15 @@ def _detect_shadows(
             and other.candidate != winner.candidate
             and "site-packages" in (other.candidate or "")
         ):
-                shadows.append(ShadowWarning(
+            shadows.append(
+                ShadowWarning(
                     shadow_path=winner.candidate or "unknown",
                     shadowed_module=top_level,
                     description=(
                         f"'{winner.candidate}' shadows installed package at '{other.candidate}'"
                     ),
-                ))
+                )
+            )
 
     return shadows
 

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -114,10 +114,15 @@ class TestVenvDetection:
             assert venv.is_active is True
 
     def test_no_venv_when_prefix_equals_base(self) -> None:
-        env_clean = {k: v for k, v in os.environ.items()
-                     if k not in ("CONDA_DEFAULT_ENV", "PIPENV_ACTIVE", "POETRY_ACTIVE")}
-        with patch.dict(os.environ, env_clean, clear=True), \
-             patch.object(sys, "prefix", sys.base_prefix):
+        env_clean = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in ("CONDA_DEFAULT_ENV", "PIPENV_ACTIVE", "POETRY_ACTIVE")
+        }
+        with (
+            patch.dict(os.environ, env_clean, clear=True),
+            patch.object(sys, "prefix", sys.base_prefix),
+        ):
             venv = _detect_venv()
             assert venv.is_active is False
             assert venv.type == "none"
@@ -134,11 +139,16 @@ class TestVenvDetection:
         (win_lib / "orig-prefix.txt").write_text("/usr")
         (tmp_path / "fakevenv" / "pyvenv.cfg").write_text("home = /usr/bin\n")
 
-        env_clean = {k: v for k, v in os.environ.items()
-                     if k not in ("CONDA_DEFAULT_ENV", "PIPENV_ACTIVE", "POETRY_ACTIVE")}
-        with patch.dict(os.environ, env_clean, clear=True), \
-             patch.object(sys, "prefix", fake_prefix), \
-             patch.object(sys, "base_prefix", "/usr"):
+        env_clean = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in ("CONDA_DEFAULT_ENV", "PIPENV_ACTIVE", "POETRY_ACTIVE")
+        }
+        with (
+            patch.dict(os.environ, env_clean, clear=True),
+            patch.object(sys, "prefix", fake_prefix),
+            patch.object(sys, "base_prefix", "/usr"),
+        ):
             venv = _detect_venv()
             assert venv.type == "virtualenv"
             assert venv.is_active is True
@@ -149,11 +159,16 @@ class TestVenvDetection:
         cfg_text = "home = /usr/bin\nuv = 0.1.0\nprompt = myproject\n"
         (tmp_path / "uvvenv" / "pyvenv.cfg").write_text(cfg_text)
 
-        env_clean = {k: v for k, v in os.environ.items()
-                     if k not in ("CONDA_DEFAULT_ENV", "PIPENV_ACTIVE", "POETRY_ACTIVE")}
-        with patch.dict(os.environ, env_clean, clear=True), \
-             patch.object(sys, "prefix", fake_prefix), \
-             patch.object(sys, "base_prefix", "/usr"):
+        env_clean = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in ("CONDA_DEFAULT_ENV", "PIPENV_ACTIVE", "POETRY_ACTIVE")
+        }
+        with (
+            patch.dict(os.environ, env_clean, clear=True),
+            patch.object(sys, "prefix", fake_prefix),
+            patch.object(sys, "base_prefix", "/usr"),
+        ):
             venv = _detect_venv()
             assert venv.type == "uv"
             assert venv.prompt == "myproject"
@@ -164,11 +179,16 @@ class TestVenvDetection:
         cfg_text = "home = /usr/bin\nuv = 0.1.0\nprompt = \n"
         (tmp_path / "uvvenv2" / "pyvenv.cfg").write_text(cfg_text)
 
-        env_clean = {k: v for k, v in os.environ.items()
-                     if k not in ("CONDA_DEFAULT_ENV", "PIPENV_ACTIVE", "POETRY_ACTIVE")}
-        with patch.dict(os.environ, env_clean, clear=True), \
-             patch.object(sys, "prefix", fake_prefix), \
-             patch.object(sys, "base_prefix", "/usr"):
+        env_clean = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in ("CONDA_DEFAULT_ENV", "PIPENV_ACTIVE", "POETRY_ACTIVE")
+        }
+        with (
+            patch.dict(os.environ, env_clean, clear=True),
+            patch.object(sys, "prefix", fake_prefix),
+            patch.object(sys, "base_prefix", "/usr"),
+        ):
             venv = _detect_venv()
             assert venv.type == "uv"
             assert venv.prompt == "uvvenv2"
@@ -179,12 +199,17 @@ class TestVenvDetection:
         win_lib.mkdir(parents=True)
         (win_lib / "orig-prefix.txt").write_text("C:\\Python312")
 
-        env_clean = {k: v for k, v in os.environ.items()
-                     if k not in ("CONDA_DEFAULT_ENV", "PIPENV_ACTIVE", "POETRY_ACTIVE")}
-        with patch.dict(os.environ, env_clean, clear=True), \
-             patch.object(sys, "prefix", fake_prefix), \
-             patch.object(sys, "base_prefix", "C:\\Python312"), \
-             patch.object(sys, "platform", "win32"):
+        env_clean = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in ("CONDA_DEFAULT_ENV", "PIPENV_ACTIVE", "POETRY_ACTIVE")
+        }
+        with (
+            patch.dict(os.environ, env_clean, clear=True),
+            patch.object(sys, "prefix", fake_prefix),
+            patch.object(sys, "base_prefix", "C:\\Python312"),
+            patch.object(sys, "platform", "win32"),
+        ):
             venv = _detect_venv()
             assert venv.type == "virtualenv"
 
@@ -192,9 +217,11 @@ class TestVenvDetection:
         fake_prefix = str(tmp_path / "poetryvenv")
         (tmp_path / "poetryvenv").mkdir()
 
-        with patch.dict(os.environ, {"POETRY_ACTIVE": "1"}, clear=False), \
-             patch.object(sys, "prefix", fake_prefix), \
-             patch.object(sys, "base_prefix", "/usr"):
+        with (
+            patch.dict(os.environ, {"POETRY_ACTIVE": "1"}, clear=False),
+            patch.object(sys, "prefix", fake_prefix),
+            patch.object(sys, "base_prefix", "/usr"),
+        ):
             venv = _detect_venv()
             assert venv.type == "poetry"
 
@@ -204,12 +231,17 @@ class TestVenvDetection:
         cfg = tmp_path / "badvenv" / "pyvenv.cfg"
         cfg.write_text("home = /usr\n")
 
-        env_clean = {k: v for k, v in os.environ.items()
-                     if k not in ("CONDA_DEFAULT_ENV", "PIPENV_ACTIVE", "POETRY_ACTIVE")}
-        with patch.dict(os.environ, env_clean, clear=True), \
-             patch.object(sys, "prefix", fake_prefix), \
-             patch.object(sys, "base_prefix", "/usr"), \
-             patch.object(Path, "read_text", side_effect=OSError("permission denied")):
+        env_clean = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in ("CONDA_DEFAULT_ENV", "PIPENV_ACTIVE", "POETRY_ACTIVE")
+        }
+        with (
+            patch.dict(os.environ, env_clean, clear=True),
+            patch.object(sys, "prefix", fake_prefix),
+            patch.object(sys, "base_prefix", "/usr"),
+            patch.object(Path, "read_text", side_effect=OSError("permission denied")),
+        ):
             venv = _detect_venv()
             assert venv.is_active is True
 
@@ -224,11 +256,16 @@ class TestVenvDetection:
         unix_lib.mkdir(parents=True)
         (unix_lib / "orig-prefix.txt").write_text("C:\\Python312")
 
-        env_clean = {k: v for k, v in os.environ.items()
-                     if k not in ("CONDA_DEFAULT_ENV", "PIPENV_ACTIVE", "POETRY_ACTIVE")}
-        with patch.dict(os.environ, env_clean, clear=True), \
-             patch.object(sys, "prefix", fake_prefix), \
-             patch.object(sys, "base_prefix", "C:\\Python312"):
+        env_clean = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in ("CONDA_DEFAULT_ENV", "PIPENV_ACTIVE", "POETRY_ACTIVE")
+        }
+        with (
+            patch.dict(os.environ, env_clean, clear=True),
+            patch.object(sys, "prefix", fake_prefix),
+            patch.object(sys, "base_prefix", "C:\\Python312"),
+        ):
             venv = _detect_venv()
             assert venv.type == "virtualenv"
 
@@ -270,18 +307,24 @@ class TestPackageManager:
             assert _detect_package_manager() == "pipenv"
 
     def test_poetry_manager(self) -> None:
-        env = {k: v for k, v in os.environ.items()
-               if k not in ("CONDA_DEFAULT_ENV", "PIPENV_ACTIVE")}
+        env = {
+            k: v for k, v in os.environ.items() if k not in ("CONDA_DEFAULT_ENV", "PIPENV_ACTIVE")
+        }
         env["POETRY_ACTIVE"] = "1"
         with patch.dict(os.environ, env, clear=True):
             assert _detect_package_manager() == "poetry"
 
     def test_pyenv_manager(self) -> None:
-        env = {k: v for k, v in os.environ.items()
-               if k not in ("CONDA_DEFAULT_ENV", "PIPENV_ACTIVE", "POETRY_ACTIVE")}
-        with patch.dict(os.environ, env, clear=True), \
-             patch.object(sys, "executable", "/home/user/.pyenv/shims/python"), \
-             patch("pywho.inspector.Path") as mock_path:
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in ("CONDA_DEFAULT_ENV", "PIPENV_ACTIVE", "POETRY_ACTIVE")
+        }
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch.object(sys, "executable", "/home/user/.pyenv/shims/python"),
+            patch("pywho.inspector.Path") as mock_path,
+        ):
             cfg = MagicMock()
             cfg.exists.return_value = False
             mock_path.return_value.__truediv__ = lambda self, other: cfg
@@ -290,31 +333,43 @@ class TestPackageManager:
     def test_uv_manager(self, tmp_path: Path) -> None:
         cfg = tmp_path / "pyvenv.cfg"
         cfg.write_text("uv = 0.5.0\n")
-        env = {k: v for k, v in os.environ.items()
-               if k not in ("CONDA_DEFAULT_ENV", "PIPENV_ACTIVE", "POETRY_ACTIVE")}
-        with patch.dict(os.environ, env, clear=True), \
-             patch.object(sys, "prefix", str(tmp_path)):
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in ("CONDA_DEFAULT_ENV", "PIPENV_ACTIVE", "POETRY_ACTIVE")
+        }
+        with patch.dict(os.environ, env, clear=True), patch.object(sys, "prefix", str(tmp_path)):
             assert _detect_package_manager() == "uv"
 
     def test_cfg_exists_but_no_uv(self, tmp_path: Path) -> None:
         cfg = tmp_path / "pyvenv.cfg"
         cfg.write_text("home = /usr/bin\n")
-        env = {k: v for k, v in os.environ.items()
-               if k not in ("CONDA_DEFAULT_ENV", "PIPENV_ACTIVE", "POETRY_ACTIVE")}
-        with patch.dict(os.environ, env, clear=True), \
-             patch.object(sys, "prefix", str(tmp_path)), \
-             patch.object(sys, "executable", "/usr/bin/python"):
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in ("CONDA_DEFAULT_ENV", "PIPENV_ACTIVE", "POETRY_ACTIVE")
+        }
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch.object(sys, "prefix", str(tmp_path)),
+            patch.object(sys, "executable", "/usr/bin/python"),
+        ):
             assert _detect_package_manager() == "pip"
 
     def test_uv_manager_cfg_read_error(self, tmp_path: Path) -> None:
         cfg = tmp_path / "pyvenv.cfg"
         cfg.write_text("uv = 0.5\n")
-        env = {k: v for k, v in os.environ.items()
-               if k not in ("CONDA_DEFAULT_ENV", "PIPENV_ACTIVE", "POETRY_ACTIVE")}
-        with patch.dict(os.environ, env, clear=True), \
-             patch.object(sys, "prefix", str(tmp_path)), \
-             patch.object(sys, "executable", "/usr/bin/python"), \
-             patch.object(Path, "read_text", side_effect=OSError("permission denied")):
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in ("CONDA_DEFAULT_ENV", "PIPENV_ACTIVE", "POETRY_ACTIVE")
+        }
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch.object(sys, "prefix", str(tmp_path)),
+            patch.object(sys, "executable", "/usr/bin/python"),
+            patch.object(Path, "read_text", side_effect=OSError("permission denied")),
+        ):
             assert _detect_package_manager() == "pip"
 
 
@@ -390,6 +445,7 @@ class TestToDict:
 
     def test_to_dict_json_serializable(self) -> None:
         import json
+
         report = inspect_environment(include_packages=True)
         d = report.to_dict()
         json_str = json.dumps(d)

--- a/tests/test_scan_formatter.py
+++ b/tests/test_scan_formatter.py
@@ -8,9 +8,7 @@ from pywho.scan_formatter import format_scan
 from pywho.scanner import Severity, ShadowResult
 
 
-def _shadow(
-    path: str, name: str, shadows: str, severity: Severity
-) -> ShadowResult:
+def _shadow(path: str, name: str, shadows: str, severity: Severity) -> ShadowResult:
     return ShadowResult(
         path=Path(path),
         module_name=name,

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -16,21 +16,27 @@ class TestSupportsColor:
             assert supports_color() is True
 
     def test_ansicon_returns_true(self) -> None:
-        with patch.dict(os.environ, {"ANSICON": "1"}), \
-             patch("sys.stdout", new=MagicMock(isatty=lambda: False)):
+        with (
+            patch.dict(os.environ, {"ANSICON": "1"}),
+            patch("sys.stdout", new=MagicMock(isatty=lambda: False)),
+        ):
             assert supports_color() is True
 
     def test_wt_session_returns_true(self) -> None:
         env = {k: v for k, v in os.environ.items() if k != "ANSICON"}
         env["WT_SESSION"] = "1"
-        with patch.dict(os.environ, env, clear=True), \
-             patch("sys.stdout", new=MagicMock(isatty=lambda: False)):
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch("sys.stdout", new=MagicMock(isatty=lambda: False)),
+        ):
             assert supports_color() is True
 
     def test_no_terminal_returns_false(self) -> None:
         env = {k: v for k, v in os.environ.items() if k not in ("ANSICON", "WT_SESSION")}
-        with patch.dict(os.environ, env, clear=True), \
-             patch("sys.stdout", new=MagicMock(isatty=lambda: False)):
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch("sys.stdout", new=MagicMock(isatty=lambda: False)),
+        ):
             assert supports_color() is False
 
 

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -251,6 +251,7 @@ class TestFindCandidates:
 
     def test_finds_extension_module(self, tmp_path: Path) -> None:
         import importlib.machinery
+
         if importlib.machinery.EXTENSION_SUFFIXES:
             ext = importlib.machinery.EXTENSION_SUFFIXES[0]
             (tmp_path / f"fakemod{ext}").write_text("")


### PR DESCRIPTION
## Summary
- Auto-format 8 files to pass the new `ruff format --check` CI lint step
- No logic changes, only formatting (whitespace, quotes, line breaks)

## Files reformatted
- `src/pywho/cli.py`
- `src/pywho/inspector.py`
- `src/pywho/scanner.py`
- `src/pywho/tracer.py`
- `tests/test_inspector.py`
- `tests/test_scan_formatter.py`
- `tests/test_terminal.py`
- `tests/test_tracer.py`

## Test plan
- [x] All 149 tests pass locally
- [x] `ruff check` and `ruff format --check` pass
- [x] 97.79% branch coverage maintained