### PR TITLE
ci: debug codecov coverage upload with verbose mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,9 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml
+          fail_ci_if_error: true
+          verbose: true
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}


### PR DESCRIPTION
## Summary
- Enable verbose mode on codecov-action to debug why coverage badge shows "unknown"
- Explicitly specify `coverage.xml` file path
- Set `fail_ci_if_error: true` so we can see if the upload is actually failing silently

## Test plan
- [ ] CI runs and coverage job shows detailed upload logs
- [ ] If upload fails, error will be visible in the logs
