### PR TITLE
ci: add Python 3.14 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Add Python 3.14 to the CI test matrix (ubuntu/macos/windows)
- The `Programming Language :: Python :: 3.14` classifier was already in `pyproject.toml` but CI wasn't testing against it

## Note
After merging, the branch protection required status checks should be updated to include the new `test (ubuntu-latest, 3.14)`, `test (macos-latest, 3.14)`, and `test (windows-latest, 3.14)` checks.

## Test plan
- [ ] CI runs successfully for Python 3.14 across all 3 OS platforms
- [ ] Existing Python 3.9–3.13 tests remain unaffected
