### PR TITLE
docs: add Read the Docs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+mkdocs:
+  configuration: mkdocs.yml
+
+python:
+  install:
+    - requirements: requirements-docs.txt

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: pywho
-site_url: https://ahsansheraz.github.io/pywho/
+site_url: https://pywho.readthedocs.io/
 site_description: One command to explain your Python environment.
 site_author: Ahsan Sheraz
 repo_url: https://github.com/AhsanSheraz/pywho

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ pywho = "pywho.cli:main"
 Homepage = "https://github.com/AhsanSheraz/pywho"
 Repository = "https://github.com/AhsanSheraz/pywho"
 Issues = "https://github.com/AhsanSheraz/pywho/issues"
-Documentation = "https://ahsansheraz.github.io/pywho/"
+Documentation = "https://pywho.readthedocs.io/"
 Changelog = "https://github.com/AhsanSheraz/pywho/blob/main/CHANGELOG.md"
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
## Summary
- Add `.readthedocs.yaml` config for building docs on Read the Docs (MkDocs + Material theme, Python 3.11, Ubuntu 22.04)
- Update `site_url` in `mkdocs.yml` to `https://pywho.readthedocs.io/`
- Update `Documentation` URL in `pyproject.toml` to `https://pywho.readthedocs.io/`
- Add Read the Docs badge and documentation link to README

## Test plan
- [x] Verify RTD build triggers and completes successfully
- [ ] Confirm docs are accessible at https://pywho.readthedocs.io/