### PR TITLE
docs: replace uvx recommendation with caveat about ephemeral environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,7 @@ Or with [uv](https://docs.astral.sh/uv/):
 uv pip install pywho
 ```
 
-Or run without installing:
-
-```bash
-uvx pywho
-```
+> **Note:** `uvx pywho` is not recommended — it runs inside uv's ephemeral sandbox, so the output reflects that temporary environment instead of your actual project. Always install pywho into the environment you want to inspect.
 
 ## Why pywho?
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,11 +17,16 @@ pip install pywho
 uv pip install pywho
 ```
 
-## Run without installing
+## Run as module
+
+If you prefer not to install, you can run pywho directly:
 
 ```bash
-uvx pywho
+python -m pywho
 ```
+
+!!! warning "Why not `uvx pywho`?"
+    `uvx` runs tools inside an ephemeral sandbox environment. This means `pywho` would report that temporary environment instead of your actual project environment. Always install pywho into the environment you want to inspect.
 
 ## From source
 


### PR DESCRIPTION
## Summary

- Removed `uvx pywho` as a recommended installation method from README and docs
- Added a note explaining why `uvx` reports the wrong environment (uv's ephemeral sandbox instead of the user's actual project)
- Replaced with `python -m pywho` as the no-install alternative

## Context

`uvx pywho` runs inside uv's temporary sandbox, so the output reflects that ephemeral environment — not useful for debugging your actual project setup.