### PR TITLE
chore: bump version to 0.3.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pywho"
-version = "0.3.2"
+version = "0.3.3"
 description = "One command to explain your Python environment, trace imports, and detect shadows."
 readme = "README.md"
 license = "MIT"

--- a/src/pywho/__init__.py
+++ b/src/pywho/__init__.py
@@ -4,7 +4,7 @@ from pywho.inspector import EnvironmentReport, inspect_environment
 from pywho.scanner import ShadowResult, scan_path
 from pywho.tracer import TraceReport, trace_import
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 __all__ = [
     "EnvironmentReport",
     "ShadowResult",


### PR DESCRIPTION
## Summary

Re-release to include updated README and metadata on PyPI.

v0.3.2 was published before the README update (uvx caveat) and classifier upgrade (Production/Stable) were merged. PyPI doesn't allow re-uploading the same version, so this bumps to 0.3.3.

## Changes

- Version bump: `0.3.2` -> `0.3.3` in `pyproject.toml` and `__init__.py`

## After merge

Tag and push to trigger PyPI publish:
```bash
git tag v0.3.3 && git push origin v0.3.3
```